### PR TITLE
Added support for importing and exporting search settings configuration at the tenant level

### DIFF
--- a/Commands/Enums/SearchConfigurationScope.cs
+++ b/Commands/Enums/SearchConfigurationScope.cs
@@ -3,6 +3,7 @@
     public enum SearchConfigurationScope
     {
         Web,
-        Site
+        Site,
+        Subscription
     }
 }

--- a/Commands/Search/GetSearchConfiguration.cs
+++ b/Commands/Search/GetSearchConfiguration.cs
@@ -1,7 +1,11 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.Search.Administration;
+using Microsoft.SharePoint.Client.Search.Portability;
 using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Enums;
+using Resources = OfficeDevPnP.PowerShell.Commands.Properties.Resources;
 
 namespace OfficeDevPnP.PowerShell.Commands.Search
 {
@@ -15,6 +19,10 @@ namespace OfficeDevPnP.PowerShell.Commands.Search
         Code = @"PS:> Get-SPOSearchConfiguration -Scope Site",
         Remarks = "Returns the search configuration for the current site collection",
         SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Get-SPOSearchConfiguration -Scope Subscription",
+        Remarks = "Returns the search configuration for the current tenant",
+        SortOrder = 3)]
     public class GetSearchConfiguration : SPOWebCmdlet
     {
         [Parameter(Mandatory = false)]
@@ -34,6 +42,20 @@ namespace OfficeDevPnP.PowerShell.Commands.Search
                         WriteObject(ClientContext.Site.GetSearchConfiguration());
                         break;
                     }
+                case SearchConfigurationScope.Subscription:
+                {
+                    if (!ClientContext.Url.ToLower().Contains("-admin"))
+                    {
+                        throw new InvalidOperationException(Resources.CurrentSiteIsNoTenantAdminSite);
+                    }
+
+                    SearchObjectOwner owningScope = new SearchObjectOwner(ClientContext, SearchObjectLevel.SPSiteSubscription);
+                    var config = new SearchConfigurationPortability(ClientContext);
+                    ClientResult<string> configuration = config.ExportSearchConfiguration(owningScope);                
+                    ClientContext.ExecuteQueryRetry(10, 60*5*1000);
+                    WriteObject(configuration.Value);
+                    break;
+                }
             }
         }
     }

--- a/Commands/Search/SetSearchConfiguration.cs
+++ b/Commands/Search/SetSearchConfiguration.cs
@@ -1,7 +1,10 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.Search.Administration;
 using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Enums;
+using Resources = OfficeDevPnP.PowerShell.Commands.Properties.Resources;
 
 namespace OfficeDevPnP.PowerShell.Commands.Search
 {
@@ -15,6 +18,10 @@ namespace OfficeDevPnP.PowerShell.Commands.Search
         Code = @"PS:> Set-SPOSearchConfiguration -Configuration $config -Scope Site",
         Remarks = "Sets the search configuration for the current site collection",
         SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Set-SPOSearchConfiguration -Configuration $config -Scope Subscription",
+        Remarks = "Sets the search configuration for the current tenant",
+        SortOrder = 3)]
     public class SetSearchConfiguration : SPOWebCmdlet
     {
         [Parameter(Mandatory = true)]
@@ -35,6 +42,16 @@ namespace OfficeDevPnP.PowerShell.Commands.Search
                 case SearchConfigurationScope.Site:
                     {
                         ClientContext.Site.SetSearchConfiguration(Configuration);
+                        break;
+                    }
+                case SearchConfigurationScope.Subscription:
+                    {
+                        if (!ClientContext.Url.ToLower().Contains("-admin"))
+                        {
+                            throw new InvalidOperationException(Resources.CurrentSiteIsNoTenantAdminSite);
+                        }
+
+                        ClientContext.ImportSearchSettings(Configuration, SearchObjectLevel.SPSiteSubscription);
                         break;
                     }
             }


### PR DESCRIPTION
Added support for importing and exporting search settings configuration at the tenant level.

I could not use GetSearchConfiguration() from PnP.Core or the Export extension as they are hooked to Web/Site or export to file, so I added explicit code to export the settings on the tenant. Can be re-factored if Core is updated with supporting methods.