### PR TITLE
Allows Connect-SPOnline using ADFS WindowsTransport authentication me…

### DIFF
--- a/Commands/Base/ConnectSPOnline.cs
+++ b/Commands/Base/ConnectSPOnline.cs
@@ -103,12 +103,16 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
             }
             else if (UseAdfs)
             {
-                creds = GetCredentials();
-                if (creds == null)
-                {
-                    creds = Host.UI.PromptForCredential(Properties.Resources.EnterYourCredentials, "", "", "");
+                if (CurrentCredentials) {
+                    var windowsCredentials = CredentialCache.DefaultNetworkCredentials;
+                    SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), windowsCredentials, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, SkipTenantAdminCheck);
+                } else {
+                    creds = GetCredentials();
+                    if (creds == null) {
+                        creds = Host.UI.PromptForCredential(Properties.Resources.EnterYourCredentials, "", "", "");
+                        SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, SkipTenantAdminCheck);
+                    }
                 }
-                SPOnlineConnection.CurrentConnection = SPOnlineConnectionHelper.InstantiateAdfsConnection(new Uri(Url), creds, Host, MinimalHealthScore, RetryCount, RetryWait, RequestTimeout, SkipTenantAdminCheck);
             }
 #if !CLIENTSDKV15
             else if (ParameterSetName == "NativeAAD")


### PR DESCRIPTION
Using ADFS authentication against windowstransport, thus allows using Windows Integrated Authentication (Negotiate) by passing credentials from CredentialCache. 

Depends on https://github.com/OfficeDev/PnP-Sites-Core/pull/60