### PR TITLE
Fix for #123: Add-SPOFile -Checkout  does not update existing files 

### DIFF
--- a/Commands/Web/AddFile.cs
+++ b/Commands/Web/AddFile.cs
@@ -66,6 +66,7 @@ namespace OfficeDevPnP.PowerShell.Commands
                 try
                 {
                     var existingFile = SelectedWeb.GetFileByServerRelativeUrl(fileUrl);
+                    existingFile.EnsureProperty(f => f.Exists);
                     if (existingFile.Exists)
                     {
                         SelectedWeb.CheckOutFile(fileUrl);


### PR DESCRIPTION
Fix for #123: Add-SPOFile -Checkout  does not update existing files when the library has the RequireCheckout -option set