### PR TITLE
Omiting Scope will return both web and site scope

### DIFF
--- a/Commands/Branding/AddJavaScriptLink.cs
+++ b/Commands/Branding/AddJavaScriptLink.cs
@@ -11,14 +11,14 @@ namespace OfficeDevPnP.PowerShell.Commands
         Category = CmdletHelpCategory.Branding)]
     public class AddJavaScriptLink : SPOWebCmdlet
     {
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = true, HelpMessage = "Name under which to register the JavaScriptLink")]
         [Alias("Key")]
         public string Name = string.Empty;
 
-        [Parameter(Mandatory = true)]
+        [Parameter(Mandatory = true, HelpMessage = "URL to the JavaScript file to inject")]
         public string[] Url = null;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "Sequence of this JavaScript being injected. Use when you have a specific sequence with which to have JavaScript files being added to the page. I.e. jQuery library first and then jQueryUI.")]
         public int Sequence = 0;
 
         [Parameter(Mandatory = false)]
@@ -26,7 +26,7 @@ namespace OfficeDevPnP.PowerShell.Commands
         [Alias("AddToSite")]
         public SwitchParameter SiteScoped;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "Defines if this JavaScript file will be injected to every page within the current site collection or web. Default is web.")]
         public CustomActionScope Scope = CustomActionScope.Web;
 
         protected override void ExecuteCmdlet()

--- a/Commands/Branding/AddJavaScriptLink.cs
+++ b/Commands/Branding/AddJavaScriptLink.cs
@@ -9,6 +9,12 @@ namespace OfficeDevPnP.PowerShell.Commands
     [Cmdlet(VerbsCommon.Add, "SPOJavaScriptLink")]
     [CmdletHelp("Adds a link to a JavaScript file to a web or sitecollection",
         Category = CmdletHelpCategory.Branding)]
+    [CmdletExample(Code = "PS:> Add-SPOJavaScriptLink -Name jQuery -Url https://code.jquery.com/jquery.min.js -Sequence 9999 -Scope Site",
+                Remarks = "Injects a reference to the latest v1 series jQuery library to all pages within the current site collection under the name jQuery and at order 9999",
+                SortOrder = 1)]
+    [CmdletExample(Code = "PS:> Add-SPOJavaScriptLink -Name jQuery -Url https://code.jquery.com/jquery.min.js",
+                Remarks = "Injects a reference to the latest v1 series jQuery library to all pages within the current web under the name jQuery",
+                SortOrder = 2)]
     public class AddJavaScriptLink : SPOWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "Name under which to register the JavaScriptLink")]

--- a/Commands/Branding/AddJavaScriptLink.cs
+++ b/Commands/Branding/AddJavaScriptLink.cs
@@ -12,7 +12,8 @@ namespace OfficeDevPnP.PowerShell.Commands
     public class AddJavaScriptLink : SPOWebCmdlet
     {
         [Parameter(Mandatory = true)]
-        public string Key = string.Empty;
+        [Alias("Key")]
+        public string Name = string.Empty;
 
         [Parameter(Mandatory = true)]
         public string[] Url = null;
@@ -44,12 +45,12 @@ namespace OfficeDevPnP.PowerShell.Commands
 
             if (setScope == CustomActionScope.Web)
             {
-                SelectedWeb.AddJsLink(Key, Url, Sequence);
+                SelectedWeb.AddJsLink(Name, Url, Sequence);
             }
             else
             {
                 var site = ClientContext.Site;
-                site.AddJsLink(Key, Url, Sequence);
+                site.AddJsLink(Name, Url, Sequence);
             }
         }
     }

--- a/Commands/Branding/GetJavaScriptLink.cs
+++ b/Commands/Branding/GetJavaScriptLink.cs
@@ -11,26 +11,38 @@ namespace OfficeDevPnP.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "SPOJavaScriptLink")]
     [CmdletHelp("Returns all or a specific custom action(s) with location type ScriptLink", 
         Category = CmdletHelpCategory.Branding)]
+    [CmdletExample(Code = "PS:> Get-SPOJavaScriptLink",
+                Remarks = "Returns all web and site scoped JavaScriptLinks",
+                SortOrder = 1)]
+    [CmdletExample(Code = "PS:> Get-SPOJavaScriptLink -Scope Web",
+                Remarks = "Returns all site scoped JavaScriptLinks",
+                SortOrder = 2)]
+    [CmdletExample(Code = "PS:> Get-SPOJavaScriptLink -Scope Site",
+                Remarks = "Returns all web scoped JavaScriptLinks",
+                SortOrder = 3)]
+    [CmdletExample(Code = "PS:> Get-SPOJavaScriptLink -Name Test",
+                Remarks = "Returns the JavaScriptLink named Test",
+                SortOrder = 4)]
     public class GetJavaScriptLink : SPOWebCmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "Name of the Javascript link. Omit this parameter to retrieve all script links")]
         [Alias("Key")]
         public string Name = string.Empty;
 
-        [Parameter(Mandatory = false, HelpMessage = "Scope of the action, either Web (default) or Site")]
-        public CustomActionScope Scope = CustomActionScope.Web;
+        [Parameter(Mandatory = false, HelpMessage = "Scope of the action, either Web, Site or omit to return both")]
+        public CustomActionScope? Scope = null;
 
         protected override void ExecuteCmdlet()
         {
-            IEnumerable<UserCustomAction> actions = null;
+            List<UserCustomAction> actions = new List<UserCustomAction>();
 
-            if (Scope == CustomActionScope.Web)
+            if (!Scope.HasValue || Scope == CustomActionScope.Web)
             {
-                actions = SelectedWeb.GetCustomActions().Where(c => c.Location == "ScriptLink");
+                actions.AddRange(SelectedWeb.GetCustomActions().Where(c => c.Location == "ScriptLink"));
             }
-            else
+            if (!Scope.HasValue || Scope == CustomActionScope.Site)
             {
-                actions = ClientContext.Site.GetCustomActions().Where(c => c.Location == "ScriptLink");
+                actions.AddRange(ClientContext.Site.GetCustomActions().Where(c => c.Location == "ScriptLink"));
             }
 
             if (!string.IsNullOrEmpty(Name))
@@ -40,7 +52,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             }
             else
             {
-                WriteObject(actions,true);
+                WriteObject(actions, true);
             }
         }
     }

--- a/Commands/Branding/RemoveJavaScriptLink.cs
+++ b/Commands/Branding/RemoveJavaScriptLink.cs
@@ -11,9 +11,18 @@ namespace OfficeDevPnP.PowerShell.Commands
     [Cmdlet(VerbsCommon.Remove, "SPOJavaScriptLink", SupportsShouldProcess = true)]
     [CmdletHelp("Removes a JavaScript link or block from a web or sitecollection",
         Category = CmdletHelpCategory.Branding)]
+    [CmdletExample(Code = "PS:> Remove-SPOJavaScriptLink -Name jQuery",
+                Remarks = "Removes the injected JavaScript file with the name jQuery from the current web after confirmation",
+                SortOrder = 1)]
+    [CmdletExample(Code = "PS:> Remove-SPOJavaScriptLink -Name jQuery -Scope Site",
+                Remarks = "Removes the injected JavaScript file with the name jQuery from the current site collection after confirmation",
+                SortOrder = 2)]
+    [CmdletExample(Code = "PS:> Remove-SPOJavaScriptLink -Name jQuery -Scope Site -Force",
+                Remarks = "Removes the injected JavaScript file with the name jQuery from the current site collection and will not ask for confirmation",
+                SortOrder = 3)]
     public class RemoveJavaScriptLink : SPOWebCmdlet
     {
-        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "Name of the Javascript link. Omit this parameter to retrieve all script links")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "Name of the JavaScriptLink to remove")]
         [Alias("Key")]
         public string Name = string.Empty;
 
@@ -21,10 +30,10 @@ namespace OfficeDevPnP.PowerShell.Commands
         [Obsolete("Use Scope parameter")]
         public SwitchParameter FromSite;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "Use the -Force flag to bypass the confirmation question")]
         public SwitchParameter Force;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "Define if the JavaScriptLink is to be found at the web or site collection scope. Web is default.")]
         public CustomActionScope Scope = CustomActionScope.Web;
 
         protected override void ExecuteCmdlet()


### PR DESCRIPTION
Added ability to return both web and site scoped ScriptLinks by omiting the Scope parameter. Is this something you would like to include? Small risk here is that before by default it would return Site scoped results only, so it's not fully backwards compatible, but does make more sense this way in my opinion.