### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Please see following page for additional insights on the model.
 
 
 ##Code contributions
-In order to succesfully compile the PnP PowerShell solution you will _also_ have to download the [PnP-Sites-Core](https://github.com/OfficeDev/PnP-Sites-Core) repository and make the dev branch available. The PowerShell solution depends on it. In order to succesfully 
+In order to succesfully compile the PnP PowerShell solution you will _also_ have to download *and build in Visual Studio* the [PnP-Sites-Core](https://github.com/OfficeDev/PnP-Sites-Core) repository and make the dev branch available. The PowerShell solution depends on it. In order to succesfully 
 compile it, make sure that PnP-Sites-Core is located at the same level as PnP-PowerShell.
 
 So:


### PR DESCRIPTION
Added clarification that just downloading PnP-Sites-Core is not enough, it needs to be built as well to have the assemblies where the PowerShell projects are referencing to