### PR TITLE
OnlyAllowMembersViewMembership default value

### DIFF
--- a/Commands/Principals/NewGroup.cs
+++ b/Commands/Principals/NewGroup.cs
@@ -32,8 +32,8 @@ namespace OfficeDevPnP.PowerShell.Commands.Principals
         [Parameter(Mandatory = false, HelpMessage = "A switch parameter that specifies whether group members can modify membership in the group")]
         public SwitchParameter AllowMembersEditMembership;
 
-        [Parameter(Mandatory = false, HelpMessage = "A switch parameter that specifies whether only group members are allowed to view the list of members in the group")]
-        public SwitchParameter OnlyAllowMembersViewMembership;
+        [Parameter(Mandatory = false, HelpMessage = "A boolean parameter that specifies whether only group members are allowed to view the list of members in the group")]
+        public bool OnlyAllowMembersViewMembership = true;
 
         [Parameter(Mandatory = false, HelpMessage = "The e-mail address to which membership requests are sent")]
         public string RequestToJoinEmail;
@@ -70,9 +70,9 @@ namespace OfficeDevPnP.PowerShell.Commands.Principals
                 group.AllowMembersEditMembership = true;
                 dirty = true;
             }
-            if (OnlyAllowMembersViewMembership)
+            if (!OnlyAllowMembersViewMembership)
             {
-                group.OnlyAllowMembersViewMembership = true;
+                group.OnlyAllowMembersViewMembership = OnlyAllowMembersViewMembership;
                 dirty = true;
             }
             if (!string.IsNullOrEmpty(RequestToJoinEmail))


### PR DESCRIPTION
A groups default value for OnlyAllowMembersViewMembership is true and therefore a switch parameter to set OnlyAllowMembersViewMembership to true is not necessary.

I would rather use a boolean parameter to set the value as seen in my proposed change.