### PR TITLE
Get-SPOFolderItem and an SPO PSProvider

### DIFF
--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
@@ -564,6 +564,62 @@
       </TableControl>
     </View>
     <View>
+      <Name>FolderItems</Name>
+      <ViewSelectedBy>
+        <TypeName>Microsoft.SharePoint.Client.File</TypeName>
+        <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>40</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Type</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ItemCount/Length</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Time Last Modified</Label>
+            <Width>30</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "File"){
+                  $_.Length
+                  }
+                  else{
+                  $_.ItemCount
+                  }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeLastModified</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>File</Name>
       <ViewSelectedBy>
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
@@ -564,6 +564,62 @@
       </TableControl>
     </View>
     <View>
+      <Name>FolderItems</Name>
+      <ViewSelectedBy>
+        <TypeName>Microsoft.SharePoint.Client.File</TypeName>
+        <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>40</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Type</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ItemCount/Length</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Time Last Modified</Label>
+            <Width>30</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "File"){
+                  $_.Length
+                  }
+                  else{
+                  $_.ItemCount
+                  }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeLastModified</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>File</Name>
       <ViewSelectedBy>
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
@@ -564,6 +564,62 @@
       </TableControl>
     </View>
     <View>
+      <Name>FolderItems</Name>
+      <ViewSelectedBy>
+        <TypeName>Microsoft.SharePoint.Client.File</TypeName>
+        <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>40</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Type</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>ItemCount/Length</Label>
+            <Width>20</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Time Last Modified</Label>
+            <Width>30</Width>
+            <Alignment>left</Alignment>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "File"){
+                  $_.Length
+                  }
+                  else{
+                  $_.ItemCount
+                  }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeLastModified</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>File</Name>
       <ViewSelectedBy>
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>

--- a/Commands/Provider/SPOContentParameters.cs
+++ b/Commands/Provider/SPOContentParameters.cs
@@ -1,0 +1,10 @@
+using System.Management.Automation;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    public class SPOContentParameters
+    {
+        [Parameter()]
+        public SwitchParameter IsBinary { get; set; }
+    }
+}

--- a/Commands/Provider/SPOContentReaderWriter.cs
+++ b/Commands/Provider/SPOContentReaderWriter.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation.Provider;
+using Microsoft.SharePoint.Client;
+using File = Microsoft.SharePoint.Client.File;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    internal class SPOContentReaderWriter : IContentReader, IContentWriter
+    {
+        private readonly File _file;
+        private MemoryStream _stream;
+        private StreamReader _streamReader;
+        private StreamWriter _streamWriter;
+        private readonly bool _isBinary;
+
+        public SPOContentReaderWriter(File file, bool isBinary, CmdletProvider provider = null)
+        {
+            _file = file;
+            _isBinary = isBinary;
+            _stream = new MemoryStream();
+
+            var spStream = _file.OpenBinaryStream();
+            _file.Context.ExecuteQuery();
+            spStream.Value.CopyTo(_stream);
+            _stream.Position = 0;
+
+            _streamWriter = new StreamWriter(_stream);
+            _streamReader = new StreamReader(_stream);
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            _stream.Seek(offset, origin);
+        }
+
+        public IList Write(IList content)
+        {
+            if (!_isBinary)
+            {
+                foreach (string str in content)
+                {
+                    _streamWriter.WriteLine(str);
+                }
+            }
+            else
+            {
+                foreach (var obj in content)
+                {
+                    if (obj is byte)
+                    {
+                        _stream.WriteByte((byte)obj);
+                    }
+                    else if (obj is char)
+                    {
+                        _stream.WriteByte(Convert.ToByte((char)obj));
+                    }
+                }
+            }
+
+            _streamWriter.Flush();
+            _stream.Position = 0;
+            File.SaveBinaryDirect((_file.Context as ClientContext), _file.ServerRelativeUrl, _stream, true);
+            return content;
+        }
+
+        public IList Read(long readCount)
+        {
+            var list = new List<object>();
+            long counter = 0;
+            if (!_isBinary)
+            {
+                while (!_streamReader.EndOfStream && (counter < readCount || readCount < 1))
+                {
+                    list.Add(_streamReader.ReadLine());
+                    counter++;
+                }
+
+            }
+            else
+            {
+                while (counter < readCount || readCount < 1)
+                {
+                    var value = _stream.ReadByte();
+                    if (value == -1) break;
+
+                    list.Add((byte)value);
+                    counter++;
+                }
+            }
+            return list;
+
+        }
+
+        public void Close()
+        {
+            if (_streamReader != null)
+            {
+                _streamReader.Close();
+            }
+
+            if (_streamWriter != null)
+            {
+                _streamWriter.Close();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_streamReader != null)
+            {
+                _streamReader.Dispose();
+                _streamReader = null;
+            }
+
+            if (_streamWriter != null)
+            {
+                _streamWriter.Dispose();
+                _streamWriter = null;
+            }
+
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+            }
+        }
+
+    }
+}

--- a/Commands/Provider/SPODriveCacheItem.cs
+++ b/Commands/Provider/SPODriveCacheItem.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    internal class SPODriveCacheItem
+    {
+        public string Path { get; set; }
+        public DateTime LastRefresh { get; set; }
+        public object Item { get; set; }
+    }
+}

--- a/Commands/Provider/SPODriveInfo.cs
+++ b/Commands/Provider/SPODriveInfo.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    internal class SPODriveInfo : PSDriveInfo
+    {
+        public Web Web { get; set; }
+        public string NormalizedRoot { get; set; }
+
+        internal bool IsNotClonedContext { get; set; }
+        internal int Timeout { get; set; }
+        internal List<SPODriveCacheItem> CachedItems { get; set; }
+
+        public SPODriveInfo(PSDriveInfo driveInfo) : base(driveInfo)
+        {
+            CachedItems = new List<SPODriveCacheItem>();
+        }
+    }
+}

--- a/Commands/Provider/SPODriveParameters.cs
+++ b/Commands/Provider/SPODriveParameters.cs
@@ -1,0 +1,21 @@
+using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    public class SPODriveParameters
+    {
+        [Parameter()]
+        public Web Web { get; set; }
+
+        [Parameter()]
+        public string Url { get; set; }
+
+        [Parameter()]
+        public int CacheTimeout { get; set; }
+
+        [Parameter()]
+        public SwitchParameter UseCurrentSPOContext { get; set; }
+
+    }
+}

--- a/Commands/Provider/SPOProvider.cs
+++ b/Commands/Provider/SPOProvider.cs
@@ -1,0 +1,926 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+using System.Text.RegularExpressions;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.PowerShell.Commands.Base;
+using File = Microsoft.SharePoint.Client.File;
+using PnPResources = SharePointPnP.PowerShell.Commands.Properties.Resources;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    [CmdletProvider("SPO", ProviderCapabilities.ShouldProcess)]
+    public class SPOProvider : NavigationCmdletProvider, IContentCmdletProvider
+    {
+        //Private properties
+        private const string Pattern = @"^[\\w\\d\\.\\s]*$";
+        private const string PathSeparator = "/";
+        private const int DefaultCacheTimeout = 1000;
+
+        //Init
+        protected override ProviderInfo Start(ProviderInfo providerInfo)
+        {
+#if DEBUG
+            SessionState.PSVariable.Set("WebRequestCounter", 0);
+#endif
+            return base.Start(providerInfo);
+        }
+
+        protected override PSDriveInfo NewDrive(PSDriveInfo drive)
+        {
+            WriteVerbose(string.Format("SPOProvider::NewDrive (Drive.Name = ’{0}’, Drive.Root = ’{1}’)", drive.Name, drive.Root));
+
+            var spoParametes = DynamicParameters as SPODriveParameters;
+            var spoDrive = new SPODriveInfo(drive);
+            if (spoParametes != null && spoParametes.UseCurrentSPOContext)
+            {
+                if (SPOnlineConnection.CurrentConnection != null)
+                {
+                    spoDrive.Web = SPOnlineConnection.CurrentConnection.Context.Web;
+                }
+                else
+                {
+                    WriteErrorInternal(PnPResources.NoConnection, spoDrive, ErrorCategory.ConnectionError);
+                }
+            }
+            else if (spoParametes != null && spoParametes.Web != null)
+            {
+                var webUrl = spoParametes.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                spoDrive.Web = spoParametes.Web.Context.Clone(webUrl).Web;
+            }
+            else if (spoParametes != null && spoParametes.Url != null && SPOnlineConnection.CurrentConnection != null)
+            {
+                var cloneCtx = SPOnlineConnection.CurrentConnection.Context.Clone(spoParametes.Url);
+                spoDrive.Web = cloneCtx.Web;
+
+            }
+            else if (SPOnlineConnection.CurrentConnection != null)
+            {
+                var webUrl = SPOnlineConnection.CurrentConnection.Context.Web.EnsureProperty(w => w.Url);
+                spoDrive.Web = SPOnlineConnection.CurrentConnection.Context.Clone(webUrl).Web;
+            }
+            else
+            {
+                WriteErrorInternal(PnPResources.NoConnection, spoDrive, ErrorCategory.ConnectionError);
+            }
+
+            spoDrive.Timeout = (spoParametes != null && spoParametes.CacheTimeout != default(int)) ? spoParametes.CacheTimeout : DefaultCacheTimeout;
+
+#if DEBUG
+            spoDrive.Web.Context.ExecutingWebRequest += (sender, args) =>
+            {
+                var counter = (int)SessionState.PSVariable.Get("WebRequestCounter").Value;
+                counter++;
+                SessionState.PSVariable.Set("WebRequestCounter", counter);
+            };
+#endif
+
+            spoDrive.NormalizedRoot = NormalizeRoot(spoDrive);
+
+            if (!ValidateRoot(spoDrive))
+            {
+                WriteErrorInternal("Unvalid root", spoDrive.Root, ErrorCategory.InvalidArgument);
+            }
+
+            //return spoDrive;
+
+            //Set root to normalized root
+            return new SPODriveInfo(new PSDriveInfo(spoDrive.Name ,spoDrive.Provider, spoDrive.NormalizedRoot, spoDrive.Description, spoDrive.Credential, spoDrive.DisplayRoot))
+            {
+                Web = spoDrive.Web,
+                Timeout = spoDrive.Timeout,
+                NormalizedRoot = spoDrive.NormalizedRoot,
+                IsNotClonedContext = spoDrive.IsNotClonedContext
+               
+            };
+        }
+
+        protected override object NewDriveDynamicParameters()
+        {
+            return new SPODriveParameters();
+        }
+
+        protected override PSDriveInfo RemoveDrive(PSDriveInfo drive)
+        {
+            WriteVerbose(string.Format("SPOProvider::RemoveDrive (Drive.Name = ’{0}’)", drive.Name));
+
+            var spoDrive = drive as SPODriveInfo;
+            if (spoDrive == null) return null;
+
+            if (spoDrive.IsNotClonedContext)
+            {
+                spoDrive.Web.Context.Dispose();
+            }
+
+            return spoDrive;
+        }
+
+        //Validate
+        protected override bool IsValidPath(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::IsValidPath (Path = ’{0}’)", path));
+            return Regex.IsMatch(path, Pattern);
+        }
+
+        protected override bool IsItemContainer(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::IsItemContainer (Path = ’{0}’)", path));
+
+            try
+            {
+                if (PathIsDrive(path)) return true;
+                return GetFileOrFolder(path, false) is Folder;
+            }
+            catch (Exception e)
+            {
+                WriteErrorInternal(e.Message, path, exception: e);
+                return false;
+            }
+        }
+
+        protected override bool ItemExists(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::ItemExists (Path = ’{0}’)", path));
+
+            if (PathIsDrive(path)) return true;
+            try
+            {
+                return GetFileOrFolder(path, false) != null;
+            }
+            catch (Exception e)
+            {
+                WriteErrorInternal(e.Message, path, exception: e);
+                return false;
+            }
+        }
+
+        protected override bool HasChildItems(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::HasChildItems (Path = ’{0}’)", path));
+
+            try
+            {
+                var folder = GetFileOrFolder(path) as Folder;
+                if (folder != null)
+                {
+                    var folderAndFiles = GetFolderItems(folder, false);
+                    return folderAndFiles.Any();
+                }
+                return false;
+            }
+            catch (Exception e)
+            {
+                WriteErrorInternal(e.Message, path, exception: e);
+                return false;
+            }
+        }
+
+        //Path
+        protected override string MakePath(string parent, string child)
+        {
+            var result = base.MakePath(parent, child);
+            WriteVerbose(string.Format("SPOProvider::MakePath (parent = ’{0}’, child = ’{1}’) = {2}", parent, child, result));
+            return result;
+        }
+
+        protected override string GetParentPath(string path, string root)
+        {
+            var result = base.GetParentPath(path, root);
+            WriteVerbose(string.Format("SPOProvider::GetParentPath (path = ’{0}’, root = ’{1}’) = {2}", path, root, result));
+            return result;
+        }
+
+        protected override string GetChildName(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetChildName YYY (path = ’{0}’) = {1}", path, base.GetChildName(path)));
+            return base.GetChildName(path);
+        }
+
+        protected override string NormalizeRelativePath(string path, string basePath)
+        {
+            var result = base.NormalizeRelativePath(path, basePath);
+            WriteVerbose(string.Format("SPOProvider::NormalizeRelativePath (path = ’{0}’, basePath = ’{1}’) = {2}", path, basePath, result));
+            return result;
+        }
+
+        //Get
+        protected override void GetItem(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetItem (Path = ’{0}’)", path));
+
+            var obj = GetFileOrFolder(path);
+            if (obj != null)
+            {
+                WriteItemObject(obj, GetServerRelativePath(path), (obj is Folder));
+            }
+        }
+
+        protected override void GetChildItems(string path, bool recurse)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetChildItems (Path = ’{0}’)", path));
+
+            var folder = GetFileOrFolder(path) as Folder;
+            if (folder != null)
+            {
+                WriteItemObject(string.Format("\nFolder: {0}\n", folder.ServerRelativeUrl), GetServerRelativePath(path), true);
+
+                var folderAndFiles = GetFolderItems(folder).ToArray();
+                folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => WriteItemObject(subFolder, GetServerRelativePath(path), true));
+                folderAndFiles.OfType<File>().ToList().ForEach(file => WriteItemObject(file, GetServerRelativePath(path), false));
+
+                if (recurse)
+                {
+                    folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => GetChildItems(subFolder.ServerRelativeUrl, true));
+                }
+            }
+            else
+            {
+                WriteErrorInternal("No folder at end of path", path, ErrorCategory.InvalidOperation);
+            }
+        }
+
+        protected override void GetChildNames(string path, ReturnContainers returnContainers)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetChildNames (Path = ’{0}’)", path));
+
+            var folder = GetFileOrFolder(path) as Folder;
+            if (folder != null)
+            {
+                var folderAndFiles = GetFolderItems(folder).ToArray();
+
+                folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => WriteItemObject(subFolder.Name, GetServerRelativePath(path), true));
+                folderAndFiles.OfType<File>().ToList().ForEach(file => WriteItemObject(file.Name, GetServerRelativePath(path), false));
+            }
+            else
+            {
+                WriteErrorInternal("No folder at end of path", path, ErrorCategory.InvalidOperation);
+            }
+        }
+
+        //Set
+        protected override void CopyItem(string path, string copyPath, bool recurse)
+        {
+            WriteVerbose(string.Format("SPOProvider::CopyItem (Path = ’{0}’, copyPath = ’{1}’)", path, copyPath));
+
+            if (!IsSameDrive(path, copyPath))
+            {
+                var msg = "Copy between drives is not implemented, yet";
+                var err = new NotImplementedException(msg);
+                WriteErrorInternal(msg, path, ErrorCategory.NotImplemented, exception:err);
+                return;
+            }
+
+            var source = GetFileOrFolder(path);
+            if (source == null) return;
+
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return;
+
+            var targetUrl = GetServerRelativePath(copyPath);
+            var isTargetFile = targetUrl.Split(PathSeparator.ToCharArray()).Last().Contains(".");
+            var targetFolderPath = (isTargetFile) ? GetParentServerRelativePath(targetUrl) : targetUrl;
+            var targetFolder = spoDrive.Web.EnsureFolderPath(PathSeparator + GetWebRelativePath(targetFolderPath));
+
+            if (ShouldProcess(string.Format("Copy {0} to {1}", GetServerRelativePath(path), targetUrl)))
+            {
+                if (source is File)
+                {
+                    var sourceFile = source as File;
+                    if (isTargetFile)
+                    {
+                        sourceFile.CopyTo(targetUrl, Force);
+                    }
+                    else
+                    {
+                        sourceFile.CopyTo(targetFolderPath + PathSeparator + sourceFile.Name, Force);
+                    }
+                    sourceFile.Context.ExecuteQueryRetry();
+                }
+                else if (source is Folder && !isTargetFile)
+                {
+                    var sourceFolder = source as Folder;
+                    var folderAndFiles = GetFolderItems(sourceFolder);
+
+                    foreach (var folder in folderAndFiles.OfType<Folder>())
+                    {
+                        var newSubFolder = targetFolder.CreateFolder(folder.Name);
+                        if (recurse)
+                        {
+                            CopyItem(folder.ServerRelativeUrl, newSubFolder.ServerRelativeUrl, recurse);
+                        }
+                    }
+                    foreach (var file in folderAndFiles.OfType<File>())
+                    {
+                        file.CopyTo(targetFolderPath + PathSeparator + file.Name, Force);
+                        file.Context.ExecuteQueryRetry();
+                    }
+                }
+                else
+                {
+                    WriteErrorInternal("Operation not supported", path, ErrorCategory.InvalidOperation);
+                }
+            }
+        }
+
+        protected override void MoveItem(string path, string destination)
+        {
+            WriteVerbose(string.Format("SPOProvider::CopyItem (Path = ’{0}’, destination = ’{1}’)", path, destination));
+
+            if (!IsSameDrive(path, destination))
+            {
+                var msg = "Move between drives is not implemented, yet";
+                var err = new NotImplementedException(msg);
+                WriteErrorInternal(msg, path, ErrorCategory.NotImplemented, exception: err);
+                return;
+            }
+
+            var source = GetFileOrFolder(path);
+            if (source == null) return;
+
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return;
+
+            var targetUrl = GetServerRelativePath(destination);
+            var isTargetFile = targetUrl.Split(PathSeparator.ToCharArray()).Last().Contains(".");
+            var targetFolderPath = (isTargetFile) ? GetParentServerRelativePath(targetUrl) : targetUrl;
+            var targetFolder = spoDrive.Web.EnsureFolderPath(GetWebRelativePath(targetFolderPath));
+            var moveToOperations = (Force) ? MoveOperations.Overwrite : MoveOperations.None;
+
+            if (ShouldProcess(string.Format("Move {0} to {1}", GetServerRelativePath(path), targetUrl)))
+            {
+                if (source is File)
+                {
+                    var sourceFile = source as File;
+                    if (isTargetFile)
+                    {
+                        sourceFile.MoveTo(targetUrl, moveToOperations);
+                    }
+                    else
+                    {
+                        sourceFile.MoveTo(targetFolderPath + PathSeparator + sourceFile.Name, moveToOperations);
+                    }
+                    sourceFile.Context.ExecuteQueryRetry();
+
+                }
+                else if (source is Folder && !isTargetFile)
+                {
+                    var sourceFolder = source as Folder;
+                    var folderAndFiles = GetFolderItems(sourceFolder);
+
+                    //Create new folders recursively
+                    foreach (var folder in folderAndFiles.OfType<Folder>())
+                    {
+                        var newSubFolder = targetFolder.CreateFolder(folder.Name);
+                        MoveItem(folder.ServerRelativeUrl, newSubFolder.ServerRelativeUrl);
+                    }
+                    //Move files
+                    foreach (var file in folderAndFiles.OfType<File>())
+                    {
+                        file.MoveTo(targetFolderPath + PathSeparator + file.Name, moveToOperations);
+                        file.Context.ExecuteQueryRetry();
+                    }
+                    //Remove source folders
+                    sourceFolder.DeleteObject();
+                    spoDrive.Web.Context.ExecuteQueryRetry();
+                }
+                else
+                {
+                    WriteErrorInternal("Operation not supported", path, ErrorCategory.InvalidOperation);
+                }
+            }
+
+        }
+
+        protected override void RenameItem(string path, string newName)
+        {
+            MoveItem(path, GetParentServerRelativePath(path) + PathSeparator + newName);
+        }
+
+        protected override void RemoveItem(string path, bool recurse)
+        {
+            WriteVerbose(string.Format("SPOProvider::CopyItem (Path = ’{0}’)", path));
+
+            var obj = GetFileOrFolder(path);
+
+            if (obj != null && ShouldProcess(GetServerRelativePath(path), string.Format("{0} {1}", (Force) ? "Delete" : "Recycle", obj.GetType().Name)))
+            {
+                if (obj is File)
+                {
+                    var file = obj as File;
+                    if (Force)
+                    {
+                        file.DeleteObject();
+                    }
+                    else
+                    {
+                        file.Recycle();
+                    }
+                    file.Context.ExecuteQueryRetry();
+                }
+                else if (obj is Folder)
+                {
+                    var folder = obj as Folder;
+                    if (Force)
+                    {
+                        folder.DeleteObject();
+                    }
+                    else
+                    {
+                        folder.Recycle();
+                    }
+
+                    folder.Context.ExecuteQueryRetry();
+                }
+            }
+        }
+
+        protected override void NewItem(string path, string itemTypeName, object newItemValue)
+        {
+            WriteVerbose(string.Format("SPOProvider::CopyItem (Path = ’{0}’, itemTypeName = ’{1}’)", path, itemTypeName));
+
+            var itemUrl = GetServerRelativePath(path);
+            var parentUrl = GetParentServerRelativePath(itemUrl);
+            if (string.IsNullOrEmpty(itemTypeName)) itemTypeName = "File";
+
+            var parentFolder = GetFileOrFolder(parentUrl) as Folder;
+            if (parentFolder != null)
+            {
+                if (itemTypeName.Equals("file", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    parentFolder.Files.Add(new FileCreationInformation
+                    {
+                        Url = itemUrl,
+                        Content = System.Text.Encoding.UTF8.GetBytes(newItemValue as string ?? string.Empty),
+                        Overwrite = Force
+                    });
+                }
+                else if (itemTypeName.Equals("folder", StringComparison.InvariantCultureIgnoreCase) || itemTypeName.Equals("directory", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var folderName = itemUrl.Split(PathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Last();
+                    if (!parentFolder.FolderExists(folderName))
+                    {
+                        parentFolder.Folders.Add(itemUrl);
+                    }
+                }
+                else
+                {
+                    WriteErrorInternal("Only File or Folder (Directory) supported for Type", path, ErrorCategory.InvalidArgument);
+                }
+                parentFolder.Context.ExecuteQueryRetry();
+            }
+        }
+
+        //Content
+        public IContentReader GetContentReader(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetContentReader(path = ’{0}’)", path));
+
+            var obj = GetFileOrFolder(path);
+            if (obj is Folder)
+            {
+                WriteErrorInternal("Directories have no content", path, ErrorCategory.InvalidOperation);
+            }
+            if (obj is File)
+            {
+                var file = obj as File;
+                var isString = false;
+                var contentParameters = DynamicParameters as SPOContentParameters;
+                if (contentParameters != null)
+                {
+                    isString = contentParameters.IsBinary;
+                }
+                return new SPOContentReaderWriter(file, isString);
+            }
+
+            return null;
+        }
+
+        public object GetContentReaderDynamicParameters(string path)
+        {
+            return new SPOContentParameters();
+        }
+
+        public IContentWriter GetContentWriter(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::GetContentWriter(path = ’{0}’)", path));
+
+            var obj = GetFileOrFolder(path, false);
+            if (obj is Folder)
+            {
+                WriteErrorInternal("Directories have no content", path, ErrorCategory.InvalidOperation);
+            }
+            if (obj == null)
+            {
+                NewItem(path, "File", string.Empty);
+                obj = GetFileOrFolder(path);
+            }
+            if (obj is File)
+            {
+                var file = obj as File;
+                var isBinary = false;
+                var contentParameters = DynamicParameters as SPOContentParameters;
+                if (contentParameters != null)
+                {
+                    isBinary = contentParameters.IsBinary;
+                }
+
+                if (ShouldProcess(string.Format("Set content in {0}", GetServerRelativePath(path))))
+                {
+                    return new SPOContentReaderWriter(file, isBinary, provider: this);
+                }
+            }
+
+            return null;
+        }
+
+        public object GetContentWriterDynamicParameters(string path)
+        {
+            return new SPOContentParameters();
+        }
+
+        public void ClearContent(string path)
+        {
+            WriteVerbose(string.Format("SPOProvider::ClearContent(path = ’{0}’)", path));
+
+            var obj = GetFileOrFolder(path);
+            if (obj is Folder)
+            {
+                WriteErrorInternal("Directories have no content", path, ErrorCategory.InvalidOperation);
+            }
+            if (obj is File)
+            {
+                if (ShouldProcess(string.Format("Clear content from {0}", GetServerRelativePath(path))))
+                {
+                    var file = obj as File;
+                    File.SaveBinaryDirect(file.Context as ClientContext, file.ServerRelativeUrl, Stream.Null, true);
+                }
+            }
+        }
+
+        public object ClearContentDynamicParameters(string path)
+        {
+            return null;
+        }
+
+
+        //Helpers
+        private object GetFileOrFolder(string path, bool throwError = true)
+        {
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return null;
+
+            var serverRelativePath = GetServerRelativePath(path);
+            if (string.IsNullOrEmpty(serverRelativePath)) return null;
+
+            //Try get cached item
+            var fileOrFolder = GetCachedItem(serverRelativePath);
+            if (fileOrFolder != null) return fileOrFolder;
+
+            var web = spoDrive.Web;
+            var ctx = spoDrive.Web.Context;
+
+            var webUrl = IsPropertyAvailable(web, "ServerRelativeUrl") ? web.ServerRelativeUrl : web.EnsureProperty(w => w.ServerRelativeUrl);
+
+            //If web root return web root folder
+            if (serverRelativePath.Equals(webUrl, StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (!IsPropertyAvailable(web, "RootFolder"))
+                {
+                    web.EnsureProperty(w => w.RootFolder);
+                }
+                SetCachedItem(serverRelativePath, web.RootFolder);
+                return web.RootFolder;
+            }
+
+            //Determine if we should try file or folder first
+            var tryFileFirst = serverRelativePath.Split(PathSeparator.ToCharArray()).Last().Contains(".");
+
+            File file;
+            Folder folder;
+
+            var scope = new ExceptionHandlingScope(ctx);
+            if (tryFileFirst)
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        file = web.GetFileByServerRelativeUrl(serverRelativePath);
+                        ctx.Load(file);
+                    }
+                    using (scope.StartCatch())
+                    {
+                        folder = web.GetFolderByServerRelativeUrl(serverRelativePath);
+                        ctx.Load(folder);
+                    }
+                }
+            }
+            else
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        folder = web.GetFolderByServerRelativeUrl(serverRelativePath);
+                        ctx.Load(folder);
+                    }
+                    using (scope.StartCatch())
+                    {
+                        file = web.GetFileByServerRelativeUrl(serverRelativePath);
+                        ctx.Load(file);
+                    }
+                }
+            }
+
+            try
+            {
+                ctx.ExecuteQueryRetry();
+            }
+            catch (Exception e)
+            {
+                if (throwError)
+                {
+                    WriteErrorInternal(e.Message, path, ErrorCategory.ObjectNotFound, exception: e);
+                }
+            }
+
+
+            //Check if we got data
+            if (IsPropertyAvailable(file, "Name"))
+            {
+                SetCachedItem(serverRelativePath, file);
+                return file;
+            }
+            else if (IsPropertyAvailable(folder, "Name"))
+            {
+                SetCachedItem(serverRelativePath, folder);
+                return folder;
+            }
+            return null;
+        }
+
+        private IEnumerable<object> GetFolderItems(Folder folder, bool throwError = false)
+        {
+            try
+            {
+                if (folder != null)
+                {
+                    if (!IsPropertyAvailable(folder, "ServerRelativeUrl"))
+                    {
+                        folder.EnsureProperty(f => f.ServerRelativeUrl);
+                    }
+                    var folderAndFiles = GetCachedChildItems(folder.ServerRelativeUrl);
+                    if (folderAndFiles != null) return folderAndFiles;
+
+
+                    var files = folder.Context.LoadQuery(folder.Files).OrderBy(f => f.Name);
+                    var folders = folder.Context.LoadQuery(folder.Folders).OrderBy(f => f.Name);
+                    folder.Context.ExecuteQueryRetry();
+
+                    folderAndFiles = folders.Concat<object>(files);
+                    SetCachedChildItems(folder.ServerRelativeUrl, folderAndFiles);
+
+                    return folderAndFiles;
+                }
+            }
+            catch (Exception e)
+            {
+                if (throwError)
+                {
+                    WriteErrorInternal(e.Message, "GetFolderItems", exception: e);
+                }
+            }
+            return null;
+        }
+
+        private SPODriveInfo GetCurrentDrive(string path)
+        {
+            return PSDriveInfo as SPODriveInfo ?? GetDrive(path);
+        }
+
+        private SPODriveInfo GetDrive(string path)
+        {
+            if (!path.Contains(":")) return null;
+            return ProviderInfo.Drives.FirstOrDefault(d => path.StartsWith(d.Name, StringComparison.InvariantCultureIgnoreCase)) as SPODriveInfo;
+        }
+
+        private bool ValidateRoot(SPODriveInfo spoDrive)
+        {
+            if (!spoDrive.NormalizedRoot.StartsWith(PathSeparator)) return false;
+
+            if (spoDrive.Root.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var webUrl = IsPropertyAvailable(spoDrive.Web, "Url") ? spoDrive.Web.Url : spoDrive.Web.EnsureProperty(w => w.Url);
+                if (!spoDrive.Root.StartsWith(webUrl))
+                {
+                    return false;
+                }
+            }
+
+            var webRelativeUrl = IsPropertyAvailable(spoDrive.Web, "ServerRelativeUrl") ? spoDrive.Web.ServerRelativeUrl : spoDrive.Web.EnsureProperty(w => w.ServerRelativeUrl);
+            if (spoDrive.NormalizedRoot.StartsWith(webRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
+            {
+                //Try get root folder
+                try
+                {
+                    var rootFolder = spoDrive.Web.GetFolderByServerRelativeUrl(spoDrive.NormalizedRoot);
+                    spoDrive.Web.Context.ExecuteQueryRetry();
+                    if (rootFolder != null)
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        private bool IsPropertyAvailable(ClientObject clientObject, string propertyName)
+        {
+            return clientObject.IsObjectPropertyInstantiated(propertyName) || clientObject.IsPropertyAvailable(propertyName);
+        }
+
+        internal void WriteErrorInternal(string message, object path, ErrorCategory errorCategory = ErrorCategory.NotSpecified, bool terminate = false, Exception exception = null)
+        {
+            exception = exception ?? new Exception(message);
+            var error = new ErrorRecord(exception, message, errorCategory, path);
+
+            if (terminate)
+            {
+                ThrowTerminatingError(error);
+            }
+            else
+            {
+                WriteError(error);
+            }
+        }
+
+        //Path helpers
+        private string GetServerRelativePath(string path)
+        {
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return null;
+
+            var normalizedChild = NormalizePath(path);
+            var childWithoutDriveAndRoot = RemoveDriveFromPath(normalizedChild);
+            var normalizePath = NormalizePath(spoDrive.NormalizedRoot + PathSeparator + childWithoutDriveAndRoot, true);
+            return normalizePath;
+        }
+
+        private string GetParentServerRelativePath(string path)
+        {
+            var serverRelativePath = GetServerRelativePath(path);
+            if (string.IsNullOrEmpty(serverRelativePath)) return serverRelativePath;
+
+            var index = serverRelativePath.LastIndexOf(PathSeparator);
+            if (index > -1)
+            {
+                return serverRelativePath.Substring(0, index);
+            }
+
+            return serverRelativePath;
+        }
+
+        private string GetWebRelativePath(string serverRelativePath)
+        {
+            if (string.IsNullOrEmpty(serverRelativePath)) return serverRelativePath;
+
+            var spoDrive = GetCurrentDrive(serverRelativePath);
+            if (spoDrive == null) return null;
+
+            var webPath = IsPropertyAvailable(spoDrive.Web, "ServerRelativeUrl") ? spoDrive.Web.ServerRelativeUrl : spoDrive.Web.EnsureProperty(w => w.ServerRelativeUrl);
+            var result = Regex.Replace(serverRelativePath, string.Format(@"^{0}", webPath), string.Empty);
+            if (string.IsNullOrEmpty(result)) result = PathSeparator;
+            return result;
+        }
+
+        private string NormalizePath(string path, bool removeDuplicatePathSeparators = false)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+
+            var result = Regex.Replace(path, @"\\", PathSeparator);
+            if (removeDuplicatePathSeparators) result = Regex.Replace(result, @"/{2,}", PathSeparator);
+            if (Regex.IsMatch(result, string.Format(@"[^{0}]{{1,}}", PathSeparator))) result = result.TrimEnd(PathSeparator.ToCharArray());
+
+            return result;
+        }
+
+        private string NormalizeRoot(SPODriveInfo spoDrive)
+        {
+            var root = spoDrive.Root;
+            if (root.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Uri uri;
+                if (Uri.TryCreate(root, UriKind.Absolute, out uri))
+                {
+                    root = uri.AbsolutePath;
+                }
+            }
+
+            var normalizedRoot = NormalizePath(root + PathSeparator, true);
+            var webRelativeUrl = IsPropertyAvailable(spoDrive.Web, "ServerRelativeUrl") ? spoDrive.Web.ServerRelativeUrl : spoDrive.Web.EnsureProperty(w => w.ServerRelativeUrl);
+
+            if (!normalizedRoot.StartsWith(webRelativeUrl))
+            {
+                normalizedRoot = NormalizePath(webRelativeUrl + PathSeparator + normalizedRoot);
+            }
+
+            return normalizedRoot;
+        }
+
+        private string RemoveDriveFromPath(string path, bool removeRoot = true)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return path;
+
+            var result = Regex.Replace(path, string.Format(@"^{0}:", spoDrive.Name), string.Empty);
+            if (removeRoot) result = Regex.Replace(result, string.Format(@"^{0}", spoDrive.NormalizedRoot), string.Empty);
+
+            return result;
+
+        }
+
+        private bool PathIsDrive(string path)
+        {
+            var spoDrive = GetCurrentDrive(path);
+            if (spoDrive == null) return false;
+
+            var normalizedPath = GetServerRelativePath(path);
+            return normalizedPath.Equals(spoDrive.NormalizedRoot, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private bool IsSameDrive(string path1, string path2)
+        {
+            var drive1 = GetDrive(path1);
+            var drive2 = GetDrive(path2);
+
+            return (drive1 == drive2);
+        }
+
+        //Cache helpers
+        private object GetCachedItem(string serverRelativePath)
+        {
+            var spoDrive = GetCurrentDrive(serverRelativePath);
+            if (spoDrive == null) return null;
+
+            var cachedItem = spoDrive.CachedItems.FirstOrDefault(c => c.Path == serverRelativePath && (new TimeSpan(DateTime.Now.Ticks - c.LastRefresh.Ticks)).TotalMilliseconds < spoDrive.Timeout);
+            return (cachedItem != null) ? cachedItem.Item : null;
+
+        }
+
+        private void SetCachedItem(string serverRelativePath, object obj)
+        {
+            var spoDrive = GetCurrentDrive(serverRelativePath);
+            if (spoDrive == null) return;
+
+            spoDrive.CachedItems.RemoveAll(item => item.Path == serverRelativePath);
+            spoDrive.CachedItems.Add(new SPODriveCacheItem
+            {
+                Path = serverRelativePath,
+                LastRefresh = DateTime.Now,
+                Item = obj
+            });
+        }
+
+        private IEnumerable<object> GetCachedChildItems(string serverRelativePath)
+        {
+            var spoDrive = GetCurrentDrive(serverRelativePath);
+            if (spoDrive == null) return null;
+
+            var childItems = spoDrive.CachedItems.Where(c => GetParentServerRelativePath(c.Path) == serverRelativePath && (new TimeSpan(DateTime.Now.Ticks - c.LastRefresh.Ticks)).TotalMilliseconds < spoDrive.Timeout);
+            return childItems.Any() ? childItems.Select(c => c.Item) : null;
+        }
+
+        private void SetCachedChildItems(string parentServerRelativePath, IEnumerable<object> childItems)
+        {
+            var spoDrive = GetCurrentDrive(parentServerRelativePath);
+            if (spoDrive == null) return;
+
+            foreach (var item in childItems)
+            {
+                var name = string.Empty;
+                var folder = item as Folder;
+                var file = item as File;
+
+                if (folder != null)
+                {
+                    name = folder.Name;
+                }
+                else if (file != null)
+                {
+                    name = file.Name;
+                }
+                SetCachedItem(parentServerRelativePath.TrimEnd(PathSeparator.ToCharArray()) + PathSeparator + name, item);
+            }
+        }
+
+    }
+}

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -437,6 +437,12 @@
     <Compile Include="Principals\GetGroupPermissions.cs" />
     <Compile Include="Principals\RemoveGroup.cs" />
     <Compile Include="Principals\SetGroup.cs" />
+    <Compile Include="Provider\SPOContentParameters.cs" />
+    <Compile Include="Provider\SPOContentReaderWriter.cs" />
+    <Compile Include="Provider\SPODriveCacheItem.cs" />
+    <Compile Include="Provider\SPODriveInfo.cs" />
+    <Compile Include="Provider\SPODriveParameters.cs" />
+    <Compile Include="Provider\SPOProvider.cs" />
     <Compile Include="Publishing\AddMasterPage.cs" />
     <Compile Include="Search\GetSiteSearchQueryResults.cs" />
     <Compile Include="Search\SetSearchConfiguration.cs" />
@@ -454,6 +460,7 @@
     <Compile Include="Branding\AddJavaScriptLink.cs" />
     <Compile Include="Branding\AddJavaScriptBlock.cs" />
     <Compile Include="WebParts\GetWebPartXml.cs" />
+    <Compile Include="Web\GetFolderItem.cs" />
     <Compile Include="Web\InvokeWebAction.cs" />
     <Compile Include="Web\EnsureFolder.cs" />
     <Compile Include="Web\AddFolder.cs" />

--- a/Commands/Web/GetFolderItem.cs
+++ b/Commands/Web/GetFolderItem.cs
@@ -1,0 +1,74 @@
+﻿using System.Management.Automation;
+using Microsoft.SharePoint.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OfficeDevPnP.Core.Utilities;
+using SharePointPnP.PowerShell.CmdletHelpAttributes;
+using SharePointPnP.PowerShell.Commands;
+using File = Microsoft.SharePoint.Client.File;
+
+namespace OfficeDevPnP.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "SPOFolderItem")]
+    [CmdletHelp("List content in folder", Category = CmdletHelpCategory.Webs)]
+    public class GetFolderItem : SPOWebCmdlet
+    {
+
+        [Parameter(Mandatory = false, Position = 0, ValueFromPipeline = true)]
+        public string FolderSiteRelativeUrl;
+
+        [Parameter(Mandatory = false)]
+        [ValidateSet("Folder", "File", "All")]
+        public string ItemType = "All";
+
+        [Parameter(Mandatory = false)]
+        public string ItemName = string.Empty;
+
+        protected override void ExecuteCmdlet()
+        {
+            string serverRelativeUrl = null;
+            if (!string.IsNullOrEmpty(FolderSiteRelativeUrl))
+            {
+                var webUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
+                serverRelativeUrl = UrlUtility.Combine(webUrl, FolderSiteRelativeUrl);
+            }
+
+            var targetFolder = (string.IsNullOrEmpty(FolderSiteRelativeUrl)) ? SelectedWeb.RootFolder : SelectedWeb.GetFolderByServerRelativeUrl(serverRelativeUrl);
+            IEnumerable<File> files = null;
+            IEnumerable<Folder> folders = null;
+
+            if (ItemType == "File" || ItemType == "All")
+            {
+                files = ClientContext.LoadQuery(targetFolder.Files).OrderBy(f => f.Name);
+                if (!string.IsNullOrEmpty(ItemName))
+                {
+                    files = files.Where(f=>f.Name.Equals(ItemName, StringComparison.InvariantCultureIgnoreCase));
+                }
+            }
+            if (ItemType == "Folder" || ItemType == "All")
+            {
+                folders = ClientContext.LoadQuery(targetFolder.Folders).OrderBy(f => f.Name);
+                if (!string.IsNullOrEmpty(ItemName))
+                {
+                    folders = folders.Where(f => f.Name.Equals(ItemName, StringComparison.InvariantCultureIgnoreCase));
+                }
+            }
+            ClientContext.ExecuteQueryRetry();
+
+            switch (ItemType)
+            {
+                case "All":
+                    var foldersAndFiles = folders.Concat<object>(files);
+                    WriteObject(foldersAndFiles, true);
+                    break;
+                case "Folder":
+                    WriteObject(folders, true);
+                    break;
+                default:
+                    WriteObject(files, true);
+                    break;
+            }
+        }
+    }
+}

--- a/Documentation/GetSPOFolderItem.md
+++ b/Documentation/GetSPOFolderItem.md
@@ -1,0 +1,15 @@
+#Get-SPOFolderItem
+List content in folder
+##Syntax
+```powershell
+Get-SPOFolderItem [-ItemType <String>] [-ItemName <String>] [-Web <WebPipeBind>] [-FolderSiteRelativeUrl <String>]
+```
+
+
+##Parameters
+Parameter|Type|Required|Description
+---------|----|--------|-----------
+|FolderSiteRelativeUrl|String|False||
+|ItemName|String|False||
+|ItemType|String|False||
+|Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|


### PR DESCRIPTION
I often find that I need to know what files and folders I have in my site and a PowerShell cmdlet would come in handy. So wrote the Get-SPOFolderItem command that lists folder and file at a given path.

However even better would be navigate the site as a regular file store and be able to use commands like Get-Item, Get-ChildItem, Set-Location, Set-Content and so on. So I wrote a custom PowerShell (Drive) Provider that allow just that. 

A drive can be created with the -CreateDrive switch at Connect-SPOnline, which default creates a drive named spo:, or via the regular New-PSDrive command.

Most regular provider commands are supported, thou right now copy/move actions between sites is not supported, but piping Get-Content and Set-Content can accomplish the same thing.

To be able to show File and Folder object in the same output a new format-section was needed that handles both object at the same time (which unfortunately will take over the output format for single file/folder object as well).