### PR TITLE
Updated SPO PSProvider with cross site support

### DIFF
--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
@@ -570,7 +570,7 @@
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
       <GroupBy>
-        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2016\SPO::", "")</ScriptBlock>
+        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2013\SPO::", "")</ScriptBlock>
         <Label>Folder</Label>
       </GroupBy>
       <TableControl>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
@@ -569,6 +569,10 @@
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
+      <GroupBy>
+        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2016\SPO::", "")</ScriptBlock>
+        <Label>Folder</Label>
+      </GroupBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
@@ -596,10 +600,24 @@
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem>
-                <PropertyName>Name</PropertyName>
+                <ScriptBlock>
+                  if($_.Name -eq ""){
+                  $_.ServerRelativeUrl.TrimEnd("/").Substring($_.ServerRelativeUrl.TrimEnd("/").LastIndexof("/") + 1)
+                  }
+                  else{
+                  $_.Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
-                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "Folder" -and $_.Name -eq ""){
+                  "Folder (subweb)"
+                  }
+                  else{
+                  $_.GetType().Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
@@ -569,6 +569,10 @@
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
+      <GroupBy>
+        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2016\SPO::", "")</ScriptBlock>
+        <Label>Folder</Label>
+      </GroupBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
@@ -596,10 +600,24 @@
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem>
-                <PropertyName>Name</PropertyName>
+                <ScriptBlock>
+                  if($_.Name -eq ""){
+                  $_.ServerRelativeUrl.TrimEnd("/").Substring($_.ServerRelativeUrl.TrimEnd("/").LastIndexof("/") + 1)
+                  }
+                  else{
+                  $_.Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
-                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "Folder" -and $_.Name -eq ""){
+                  "Folder (subweb)"
+                  }
+                  else{
+                  $_.GetType().Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
@@ -569,6 +569,10 @@
         <TypeName>Microsoft.SharePoint.Client.File</TypeName>
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
+      <GroupBy>
+        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShellOnline\SPO::", "")</ScriptBlock>
+        <Label>Folder</Label>
+      </GroupBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
@@ -596,18 +600,32 @@
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem>
-                <PropertyName>Name</PropertyName>
+                <ScriptBlock>
+                  if($_.Name -eq ""){
+                  $_.ServerRelativeUrl.TrimEnd("/").Substring($_.ServerRelativeUrl.TrimEnd("/").LastIndexof("/") + 1)
+                  }
+                  else{
+                  $_.Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
-                <ScriptBlock>$_.GetType().Name</ScriptBlock>
+                <ScriptBlock>
+                  if($_.GetType().Name -eq "Folder" -and $_.Name -eq ""){
+                    "Folder (subweb)"
+                  }
+                  else{
+                    $_.GetType().Name
+                  }
+                </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>
                   if($_.GetType().Name -eq "File"){
-                  $_.Length
+                    $_.Length
                   }
                   else{
-                  $_.ItemCount
+                    $_.ItemCount
                   }
                 </ScriptBlock>
               </TableColumnItem>

--- a/Commands/Provider/SPODriveCacheWeb.cs
+++ b/Commands/Provider/SPODriveCacheWeb.cs
@@ -1,0 +1,12 @@
+using System;
+using Microsoft.SharePoint.Client;
+
+namespace SharePointPnP.PowerShell.Commands.Provider
+{
+    internal class SPODriveCacheWeb
+    {
+        public string Path { get; set; }
+        public DateTime LastRefresh { get; set; }
+        public Web Web { get; set; }
+    }
+}

--- a/Commands/Provider/SPODriveInfo.cs
+++ b/Commands/Provider/SPODriveInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.SharePoint.Client;
@@ -7,15 +8,19 @@ namespace SharePointPnP.PowerShell.Commands.Provider
     internal class SPODriveInfo : PSDriveInfo
     {
         public Web Web { get; set; }
-        public string NormalizedRoot { get; set; }
+
+        //public string NormalizedRoot => Web.IsObjectPropertyInstantiated(w=>w.ServerRelativeUrl) && Web.IsPropertyAvailable(w=>w.ServerRelativeUrl) ? Web.ServerRelativeUrl : Web.EnsureProperty(w => w.ServerRelativeUrl);
 
         internal bool IsNotClonedContext { get; set; }
-        internal int Timeout { get; set; }
+        internal int ItemTimeout { get; set; }
+        internal int WebTimeout { get; set; }
         internal List<SPODriveCacheItem> CachedItems { get; set; }
+        internal List<SPODriveCacheWeb> CachedWebs { get; set; }
 
         public SPODriveInfo(PSDriveInfo driveInfo) : base(driveInfo)
         {
             CachedItems = new List<SPODriveCacheItem>();
+            CachedWebs = new List<SPODriveCacheWeb>();
         }
     }
 }

--- a/Commands/Provider/SPODriveParameters.cs
+++ b/Commands/Provider/SPODriveParameters.cs
@@ -12,10 +12,13 @@ namespace SharePointPnP.PowerShell.Commands.Provider
         public string Url { get; set; }
 
         [Parameter()]
-        public int CacheTimeout { get; set; }
+        public int ItemCacheTimeout { get; set; }
 
         [Parameter()]
-        public SwitchParameter UseCurrentSPOContext { get; set; }
+        public int WebCacheTimeout { get; set; }
+
+        [Parameter()]
+        public ClientRuntimeContext Context { get; set; }
 
     }
 }

--- a/Commands/SharePointPnP.PowerShell.Commands.csproj
+++ b/Commands/SharePointPnP.PowerShell.Commands.csproj
@@ -443,6 +443,7 @@
     <Compile Include="Principals\SetGroup.cs" />
     <Compile Include="Provider\SPOContentParameters.cs" />
     <Compile Include="Provider\SPOContentReaderWriter.cs" />
+    <Compile Include="Provider\SPODriveCacheWeb.cs" />
     <Compile Include="Provider\SPODriveCacheItem.cs" />
     <Compile Include="Provider\SPODriveInfo.cs" />
     <Compile Include="Provider\SPODriveParameters.cs" />


### PR DESCRIPTION
Added the ability to perform actions cross site (collections).
- The provider changes context when needed.
- Set-Location takes any valid server relative url (under the same host).
- Copy-Item and Move-Item supports copying/moving files or folders to subsites and other site collections.
- Get-ChildItem shows subsites.
