### PR TITLE
Updated accessibility levels

### DIFF
--- a/Commands/Base/SPOWebCmdlet.cs
+++ b/Commands/Base/SPOWebCmdlet.cs
@@ -14,7 +14,7 @@ namespace SharePointPnP.PowerShell.Commands
         [Parameter(Mandatory = false, HelpMessage = "The web to apply the command to. Omit this parameter to use the current web.")]
         public WebPipeBind Web = new WebPipeBind();
 
-        internal Web SelectedWeb
+        protected Web SelectedWeb
         {
             get
             {

--- a/Commands/Base/SPOnlineConnection.cs
+++ b/Commands/Base/SPOnlineConnection.cs
@@ -11,7 +11,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
     public class SPOnlineConnection
     {
         internal static List<ClientContext> ContextCache { get; set; }
-        internal static SPOnlineConnection CurrentConnection { get; set; }
+        public static SPOnlineConnection CurrentConnection { get; internal set; }
         public ConnectionType ConnectionType { get; protected set; }
         public int MinimalHealthScore { get; protected set; }
         public int RetryCount { get; protected set; }


### PR DESCRIPTION
Updated accessibility levels for some internal methods to expose core functionality for custom powershell commandlets that are not a part of PnP. For example if someone want to create custom commandlets for a specific customer.