### PR TITLE
Update GetAzureADManifestKeyCredentials.cs for Certificate Thumbprint...

### DIFF
--- a/Commands/Base/GetAzureADManifestKeyCredentials.cs
+++ b/Commands/Base/GetAzureADManifestKeyCredentials.cs
@@ -39,7 +39,7 @@ namespace SharePointPnP.PowerShell.Commands.Base
 
             var keyId = Guid.NewGuid().ToString();
             
-            var thumbPrint = cert.Thumbprint
+            var thumbPrint = cert.Thumbprint;
 
             var output = string.Format("\"keyCredentials\": [\n\t{{\n\t\t\"customKeyIdentifier\": \"{0}\",\n\t\t\"keyId\": \"{1}\",\n\t\t\"type\": \"AsymmetricX509Cert\",\n\t\t\"usage\": \"Verify\",\n\t\t\"value\": \"{2}\"\n\t}}\n],\n\nCertificate Thumbprint: {3}\n", base64CertHash, keyId, base64Cert, thumbPrint);
 

--- a/Commands/Base/GetAzureADManifestKeyCredentials.cs
+++ b/Commands/Base/GetAzureADManifestKeyCredentials.cs
@@ -38,8 +38,10 @@ namespace SharePointPnP.PowerShell.Commands.Base
             var base64CertHash = Convert.ToBase64String(rawCertHash);
 
             var keyId = Guid.NewGuid().ToString();
+            
+            var thumbPrint = cert.Thumbprint
 
-            var output = string.Format("\"keyCredentials\": [\n\t{{\n\t\t\"customKeyIdentifier\": \"{0}\",\n\t\t\"keyId\": \"{1}\",\n\t\t\"type\": \"AsymmetricX509Cert\",\n\t\t\"usage\": \"Verify\",\n\t\t\"value\": \"{2}\"\n\t}}\n],", base64CertHash, keyId, base64Cert);
+            var output = string.Format("\"keyCredentials\": [\n\t{{\n\t\t\"customKeyIdentifier\": \"{0}\",\n\t\t\"keyId\": \"{1}\",\n\t\t\"type\": \"AsymmetricX509Cert\",\n\t\t\"usage\": \"Verify\",\n\t\t\"value\": \"{2}\"\n\t}}\n],\n\nCertificate Thumbprint: {3}\n", base64CertHash, keyId, base64Cert, thumbPrint);
 
             WriteObject(output);
 


### PR DESCRIPTION
Updated the Get-AzureADManifestKeyCredentials commandlet to output the Certificate Thumbprint. The Thumbprint is needed for manual installed steps and not provided by running this commandlet.