### PR TITLE
SPO Provider Fixes

### DIFF
--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2013.Commands.Format.ps1xml
@@ -570,7 +570,7 @@
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
       <GroupBy>
-        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2013\SPO::", "")</ScriptBlock>
+        <ScriptBlock>$_.PSParentPath.Replace("SharePointPnPPowerShell2013\SPO::", "")</ScriptBlock>
         <Label>Folder</Label>
       </GroupBy>
       <TableControl>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.2016.Commands.Format.ps1xml
@@ -570,7 +570,7 @@
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
       <GroupBy>
-        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShell2016\SPO::", "")</ScriptBlock>
+        <ScriptBlock>$_.PSParentPath.Replace("SharePointPnPPowerShell2016\SPO::", "")</ScriptBlock>
         <Label>Folder</Label>
       </GroupBy>
       <TableControl>

--- a/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
+++ b/Commands/ModuleFiles/SharePointPnP.PowerShell.Online.Commands.Format.ps1xml
@@ -570,7 +570,7 @@
         <TypeName>Microsoft.SharePoint.Client.Folder</TypeName>
       </ViewSelectedBy>
       <GroupBy>
-        <ScriptBlock>$_.PSPath.Replace("SharePointPnPPowerShellOnline\SPO::", "")</ScriptBlock>
+        <ScriptBlock>$_.PSParentPath.Replace("SharePointPnPPowerShellOnline\SPO::", "")</ScriptBlock>
         <Label>Folder</Label>
       </GroupBy>
       <TableControl>

--- a/Commands/Provider/SPOProvider.cs
+++ b/Commands/Provider/SPOProvider.cs
@@ -219,8 +219,8 @@ namespace SharePointPnP.PowerShell.Commands.Provider
                 var serverRelativePath = GetServerRelativePath(path);
                 var folderAndFiles = GetFolderItems(folder).ToArray();
 
-                folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => WriteItemObject(subFolder, serverRelativePath, true));
-                folderAndFiles.OfType<File>().ToList().ForEach(file => WriteItemObject(file, serverRelativePath, false));
+                folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => WriteItemObject(subFolder, subFolder.ServerRelativeUrl, true));
+                folderAndFiles.OfType<File>().ToList().ForEach(file => WriteItemObject(file, file.ServerRelativeUrl, false));
                 if (recurse)
                 {
                     folderAndFiles.OfType<Folder>().ToList().ForEach(subFolder => GetChildItems(subFolder.ServerRelativeUrl, true));

--- a/Commands/Provider/SPOProvider.cs
+++ b/Commands/Provider/SPOProvider.cs
@@ -429,8 +429,8 @@ namespace SharePointPnP.PowerShell.Commands.Provider
             }
             if (obj == null)
             {
-                NewItem(path, "File", string.Empty);
-                obj = GetFileOrFolder(path);
+                NewItem(path, "File", null);
+                obj = GetFileOrFolder(path, useChache: false);
             }
             if (obj is File)
             {
@@ -483,7 +483,7 @@ namespace SharePointPnP.PowerShell.Commands.Provider
         #region Helpers
 
         //Get helpers
-        private object GetFileOrFolder(string path, bool throwError = true)
+        private object GetFileOrFolder(string path, bool throwError = true, bool useChache = true)
         {
             var spoDrive = GetCurrentDrive(path);
             if (spoDrive == null) return null;
@@ -492,8 +492,11 @@ namespace SharePointPnP.PowerShell.Commands.Provider
             if (string.IsNullOrEmpty(serverRelativePath)) return null;
 
             //Try get cached item
-            var fileOrFolder = GetCachedItem(serverRelativePath);
-            if (fileOrFolder != null) return fileOrFolder.Item;
+            if (useChache)
+            {
+                var fileOrFolder = GetCachedItem(serverRelativePath);
+                if (fileOrFolder != null) return fileOrFolder.Item;
+            }
 
             //Find web closes to object
             var web = FindWebInPath(serverRelativePath);


### PR DESCRIPTION
- Fix so the PSObject has the correct PSPath and PSParentPath when using Get-ChildItem in the SPO Provider. 
- Changed the formatting to use the PSParentPath for grouping.
- Fix bug in Set-Content to pick up newly created file