### PR TITLE
Add support for ordering menu items and specifying external links

### DIFF
--- a/Commands/Branding/AddNavigationNode.cs
+++ b/Commands/Branding/AddNavigationNode.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.Commands.Enums;
 using System;
 using System.Management.Automation;
@@ -18,6 +18,14 @@ namespace SharePointPnP.PowerShell.Commands
         Code = @"PS:> Add-SPONavigationNode -Title ""Contoso USA"" -Url ""http://contoso.sharepoint.com/sites/contoso/usa/"" -Location ""QuickLaunch"" -Header ""Contoso""",
         Remarks = @"Adds a navigation node to the quicklaunch. The navigation node will have the title ""Contoso USA"", will link to the url ""http://contoso.sharepoint.com/sites/contoso/usa/"" and will have ""Contoso"" as a parent navigation node.",
         SortOrder = 2)]
+    [CmdletExample(
+        Code = @"PS:> Add-SPONavigationNode -Title ""Contoso"" -Url ""http://contoso.sharepoint.com/sites/contoso/"" -Location ""QuickLaunch"" -First",
+        Remarks = @"Adds a navigation node to the quicklaunch, as the first item. The navigation node will have the title ""Contoso"" and will link to the url ""http://contoso.sharepoint.com/sites/contoso/""",
+        SortOrder = 3)]
+    [CmdletExample(
+        Code = @"PS:> Add-SPONavigationNode -Title ""Contoso Pharmaceuticals"" -Url ""http://contoso.sharepoint.com/sites/contosopharma/"" -Location ""QuickLaunch"" -External",
+        Remarks = @"Adds a navigation node to the quicklaunch. The navigation node will have the title ""Contoso Pharmaceuticals"" and will link to the external url ""http://contoso.sharepoint.com/sites/contosopharma/""",
+        SortOrder = 4)]
     public class AddNavigationNode : SPOWebCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "The location of the node to add. Either TopNavigationBar, QuickLaunch or SearchNav")]
@@ -29,8 +37,14 @@ namespace SharePointPnP.PowerShell.Commands
         [Parameter(Mandatory = false, HelpMessage = "The url to navigate to when clicking the new menu item.")]
         public string Url;
 
-        [Parameter(Mandatory = false, HelpMessage = "Optionally value of a header entry to add the menu item to.")]
+        [Parameter(Mandatory = false, HelpMessage = "Optionallly value of a header entry to add the menu item to.")]
         public string Header;
+        
+        [Parameter(Mandatory = false, HelpMessage = "Add the new menu item to beginning of the collection.")]
+        public SwitchParameter First;
+        
+        [Parameter(Mandatory = false, HelpMessage = "Indicates the destination URL is outside of the site collection.")]
+        public SwitchParameter External;
 
         protected override void ExecuteCmdlet()
         {
@@ -40,10 +54,7 @@ namespace SharePointPnP.PowerShell.Commands
                 ClientContext.ExecuteQueryRetry();
                 Url = SelectedWeb.Url;
             }
-            SelectedWeb.AddNavigationNode(Title, new Uri(Url), Header, Location);
+            SelectedWeb.AddNavigationNode(Title, new Uri(Url), Header, Location, External.IsPresent, !First.IsPresent);
         }
-
     }
-
-
 }


### PR DESCRIPTION
Adds support for the `isExternal` and `asLastNode` parameters of `NavigationExtensions.AddNavigationNode` by adding `-First` and `-External` switch parameters. Excluding the switches preserves current behavior (new items are added to the end of the collection and not marked external).