### PR TITLE
Set ListItemPipeBind parameter ValueFromPipeline attribute to true to…

### DIFF
--- a/Commands/Lists/SetListItem.cs
+++ b/Commands/Lists/SetListItem.cs
@@ -30,7 +30,7 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, Title or Url of the list.")]
         public ListPipeBind List;
 
-        [Parameter(Mandatory = true, HelpMessage = "The ID of the listitem, or actual ListItem object")]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, HelpMessage = "The ID of the listitem, or actual ListItem object")]
         public ListItemPipeBind Identity;
 
         [Parameter(Mandatory = false, HelpMessage = "Specify either the name, ID or an actual content type")]
@@ -78,9 +78,11 @@ namespace SharePointPnP.PowerShell.Commands.Lists
                     }
                 }
 
-                foreach (var key in Values.Keys)
+                Hashtable values = Values ?? new Hashtable();
+
+                foreach (var key in values.Keys)
                 {
-                    item[key as string] = Values[key];
+                    item[key as string] = values[key];
                 }
 
 


### PR DESCRIPTION
… allow piping in the item(s). If the field values collection was empty, the command would throw an Object reference exception because the Hashtable was null. Now, if the Values collection is null, a new Hashtable will be created to short circuit the foreach statement across the field values and avoid the exception.