### PR TITLE
Updated category for SPOFolderToProvisioningTemplate documentation

### DIFF
--- a/Commands/Branding/ConvertFolderToProvisioningTemplate.cs
+++ b/Commands/Branding/ConvertFolderToProvisioningTemplate.cs
@@ -10,6 +10,8 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 namespace SharePointPnP.PowerShell.Commands.Branding
 {
     [Cmdlet("Convert", "SPOFolderToProvisioningTemplate")]
+    [CmdletHelp("Creates a pnp package file of an existing template xml, and includes all files in the current folder",
+        Category = CmdletHelpCategory.Branding)]
     [CmdletExample(
        Code = @"PS:> Convert-SPOFolderToProvisioningTemplate -Out template.pnp",
        Remarks = "Creates a pnp package file of an existing template xml, and includes all files in the current folder",


### PR DESCRIPTION
The command currently doesn't appear within the right category in the PowerShell documentation.