### PR TITLE
Add ability to retrieve file as File or ListItem object

### DIFF
--- a/Commands/Web/GetFile.cs
+++ b/Commands/Web/GetFile.cs
@@ -6,39 +6,65 @@ using OfficeDevPnP.Core.Utilities;
 namespace SharePointPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "SPOFile")]
-    [CmdletHelp("Downloads a file.",
+    [CmdletHelp("Retrieves a file.",
         Category = CmdletHelpCategory.Webs)]
     [CmdletExample(
         Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor",
-        Remarks = "Downloads the file and saves it to the current folder",
+        Remarks = "Retrieves the file and downloads it to the current folder",
         SortOrder = 1)]
     [CmdletExample(
         Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
-        Remarks = "Downloads the file and saves it to c:\\temp\\company.spcolor",
+        Remarks = "Retrieves the file and downloads it to c:\\temp\\company.spcolor",
         SortOrder = 2)]
-    [CmdletExample(Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsString",
-        Remarks = "Downloads the file and outputs its contents to the console",
+    [CmdletExample(
+        Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsString",
+        Remarks = "Retrieves the file and outputs its contents to the console",
         SortOrder = 3)]
     [CmdletExample(
-        Code = @"PS:> Get-SPOFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
-        Remarks = "Refers to the file by site relative URL, downloads the file and saves it to c:\\temp\\company.spcolor",
+        Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsFile",
+        Remarks = "Retrieves the file and returns it as a File object",
         SortOrder = 4)]
+    [CmdletExample(
+        Code = @"PS:> Get-SPOFile -ServerRelativeUrl /sites/project/_catalogs/themes/15/company.spcolor -AsListItem",
+        Remarks = "Retrieves the file and returns it as a ListItem object",
+        SortOrder = 5)]
+    [CmdletExample(
+        Code = @"PS:> Get-SPOFile -SiteRelativeUrl _catalogs/themes/15/company.spcolor -Path c:\temp -FileName company.spcolor",
+        Remarks = "Retrieves the file by site relative URL and downloads it to c:\\temp\\company.spcolor",
+        SortOrder = 6)]
 
     public class GetFile : SPOWebCmdlet
     {
         [Parameter(Mandatory = true, ParameterSetName = "SERVER", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "ServerAsString", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "ServerAsFile", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "ServerAsListItem", Position = 0, ValueFromPipeline = true)]
         public string ServerRelativeUrl = string.Empty;
 
         [Parameter(Mandatory = true, ParameterSetName = "SITE", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "SiteAsString", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "SiteAsFile", Position = 0, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = "SiteAsListItem", Position = 0, ValueFromPipeline = true)]
         public string SiteRelativeUrl = string.Empty;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, ParameterSetName = "SERVER")]
+        [Parameter(Mandatory = false, ParameterSetName = "SITE")]
         public string Path = string.Empty;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, ParameterSetName = "SERVER")]
+        [Parameter(Mandatory = false, ParameterSetName = "SITE")]
         public string Filename = string.Empty;
 
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, ParameterSetName = "ServerAsFile")]
+        [Parameter(Mandatory = false, ParameterSetName = "SiteAsFile")]
+        public SwitchParameter AsFile;
+
+        [Parameter(Mandatory = false, ParameterSetName = "ServerAsListItem")]
+        [Parameter(Mandatory = false, ParameterSetName = "SiteAsListItem")]
+        public SwitchParameter AsListItem;
+
+        [Parameter(Mandatory = false, ParameterSetName = "ServerAsString")]
+        [Parameter(Mandatory = false, ParameterSetName = "SiteAsString")]
         public SwitchParameter AsString;
 
         protected override void ExecuteCmdlet()
@@ -48,21 +74,52 @@ namespace SharePointPnP.PowerShell.Commands
                 Path = SessionState.Path.CurrentFileSystemLocation.Path;
             }
 
-            if (ParameterSetName == "SITE")
+            if (MyInvocation.BoundParameters.ContainsKey("SiteRelativeUrl"))
             {
                 var webUrl = SelectedWeb.EnsureProperty(w => w.ServerRelativeUrl);
                 ServerRelativeUrl = UrlUtility.Combine(webUrl, SiteRelativeUrl);
             }
 
-            if (MyInvocation.BoundParameters.ContainsKey("AsString"))
-            {
-                WriteObject(SelectedWeb.GetFileAsString(ServerRelativeUrl));
-            }
-            else
-            {
-                SelectedWeb.SaveFileToLocal(ServerRelativeUrl, Path, Filename);
-            }
+            File file = null;
 
+            switch (ParameterSetName)
+            {
+                case "SERVER":
+                case "SITE":
+                    SelectedWeb.SaveFileToLocal(ServerRelativeUrl, Path, Filename);
+                    break;
+
+                case "ServerAsFile":
+                case "SiteAsFile":
+                    file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
+
+                    ClientContext.Load(file, f => f.Author, f => f.Length,
+                        f => f.ModifiedBy, f => f.Name, f => f.TimeCreated,
+                        f => f.TimeLastModified, f => f.Title);
+
+                    ClientContext.ExecuteQueryRetry();
+
+                    WriteObject(file);
+                    break;
+
+                case "ServerAsListItem":
+                case "SiteAsListItem":
+                    file = SelectedWeb.GetFileByServerRelativeUrl(ServerRelativeUrl);
+
+                    ClientContext.Load(file, f => f.Exists, f => f.ListItemAllFields);
+
+                    ClientContext.ExecuteQueryRetry();
+                    if (file.Exists)
+                    {
+                        WriteObject(file.ListItemAllFields);
+                    }
+                    break;
+
+                case "ServerAsString":
+                case "SiteAsString":
+                    WriteObject(SelectedWeb.GetFileAsString(ServerRelativeUrl));
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
Added new parameters ``AsFile`` and ``AsListItem`` and associated parameter sets to the ``Get-SPOFile`` cmdlet to allow returning the file to the pipeline as a ``File`` or ``ListItem`` object.