### PR TITLE
Typo in alias

### DIFF
--- a/Commands/Apps/UninstallAppInstance.cs
+++ b/Commands/Apps/UninstallAppInstance.cs
@@ -6,7 +6,7 @@ using SharePointPnP.PowerShell.CmdletHelpAttributes;
 namespace SharePointPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsLifecycle.Uninstall, "PnPAppInstance", SupportsShouldProcess = true)]
-    [CmdletAlias("Uinstall-SPOAppInstance")]
+    [CmdletAlias("Uninstall-SPOAppInstance")]
     [CmdletHelp("Removes an app from a site", Category = CmdletHelpCategory.Apps)]
     [CmdletExample(Code = @"PS:> Uninstall-PnPAppInstance -Identity $appinstance", Remarks = "Uninstalls the app instance which was retrieved with the command Get-PnPAppInstance", SortOrder = 1)]
     [CmdletExample(Code = @"PS:> Uninstall-PnPAppInstance -Identity 99a00f6e-fb81-4dc7-8eac-e09c6f9132fe", Remarks = "Uninstalls the app instance with the ID '99a00f6e-fb81-4dc7-8eac-e09c6f9132fe'", SortOrder = 2)]


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample


## What is in this Pull Request ? ##
Missing `n` in command name `Uinstall-SPOAppInstance`.

This leads to this error while importing the module:

> WARNING: Some imported command names from module "SharePointPnPPowerShell2013" include unapproved verbs which might make them less discoverable.  Use the Verbose parameter for more detail or type
Get-Verb to see the list of approved verbs.